### PR TITLE
Allow src template location to be overridden

### DIFF
--- a/charm_templates_openstack/openstack_template.py
+++ b/charm_templates_openstack/openstack_template.py
@@ -87,10 +87,12 @@ class OpenStackCharmTemplate(CharmTemplate):
         os.unlink(backupname)
 
     def _clone_template(self, config, output_dir):
+        templ_url =  os.environ.get(
+            'CHARM_TEMPLATE_LOCAL_BRANCH',
+            self._TEMPLATE_URL)
         cmd = "git clone --recursive {} {}".format(
-            self._TEMPLATE_URL, output_dir
+            templ_url, output_dir
         )
-
         try:
             subprocess.check_call(cmd.split())
         except OSError as e:


### PR DESCRIPTION
When testing the generation of a charm from a template it is useful
to be able to point the charm generate at a local copy of the
template. This change allows CHARM_TEMPLATE_LOCATION to be set to
point at an alternative location.